### PR TITLE
Silence deprecation warnings if we're on Rails 3

### DIFF
--- a/lib/plugger.rb
+++ b/lib/plugger.rb
@@ -1,13 +1,27 @@
 class Plugger
-  
+
   def self.hi
     puts "Hi, I'm plugger. This is just a stub."
   end
-  
+
 end
 
 require 'rails/generators'
 require 'active_support/dependencies'
+
+unless Rails.version.to_i >= 4
+  module Rails
+    class Plugin < Engine
+
+      alias :not_silenced_initialize :initialize
+
+      def initialize(root)
+        ActiveSupport::Deprecation.silence{ self.send :not_silenced_initialize, root }
+      end
+
+    end
+  end
+end
 
 Dir["#{Dir.pwd}/vendor/plugins/*/init.rb"].each do |f|
   require_or_load f
@@ -16,7 +30,6 @@ end
 Dir["#{Dir.pwd}/vendor/plugins/**/lib/generators/**/*.rb"].each do |f|
   require_or_load f
 end
-  
-
 
 require 'plugger/plugger_tasks'
+


### PR DESCRIPTION
Since the gem doesn't seem to break anything on Rails 3.2, I figured might as well make it silence the plugin deprecation warnings.

I tested it on Rails 3.2 and Rails 4 and I _think_ it doesn't break anything.
