### PR TITLE
Fix for an issue where autoload of Rails::Generators::Actions was never triggered

### DIFF
--- a/lib/plugger.rb
+++ b/lib/plugger.rb
@@ -6,6 +6,8 @@ class Plugger
     
 end
 
+require 'rails/generators'
+
 module Rails
   module Generators
     
@@ -35,7 +37,6 @@ module Rails
   end
 end
 
-require 'rails/generators'
 require 'active_support/dependencies'
 
 Dir["#{Dir.pwd}/vendor/plugins/*/init.rb"].each do |f|


### PR DESCRIPTION
Fix for an issue where autoload of Rails::Generators::Actions was never triggered, because the module was already defined.

Generating would be broken by this.
Example error for 'rails generate moonshine':
moonshine_generator.rb:66:in `manifest': undefined method`environment' for #MoonshineGenerator:0x000000055f7530 (NoMethodError)
